### PR TITLE
Arrow updates

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral/materials_recipes.dm
+++ b/code/game/objects/items/stacks/sheets/mineral/materials_recipes.dm
@@ -96,6 +96,7 @@ STACKSIZE_MACRO(/obj/item/stack/sheet/mineral/titanium)
 
 GLOBAL_LIST_INIT(plastitanium_recipes, list ( \
 	new/datum/stack_recipe("plastitanium tile", /obj/item/stack/tile/mineral/plastitanium, 1, 4, 20), \
+	new/datum/stack_recipe("plastitanium arrow", /obj/item/ammo_casing/caseless/arrow/plastitanium, 1, 1, 1), \
 	))
 
 STACKSIZE_MACRO(/obj/item/stack/sheet/mineral/plastitanium)

--- a/code/modules/holoparasite/holoparasite_projectile.dm
+++ b/code/modules/holoparasite/holoparasite_projectile.dm
@@ -1,7 +1,3 @@
-/obj/projectile
-	/// The last thing the projectile force-pierced due to holopara shenanigans.
-	var/atom/movable/last_holopara_pierce
-
 /obj/projectile/holoparasite
 	name = "crystal spray"
 	icon_state = "guardian"

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -1,3 +1,15 @@
+#define UNFINISHED "unfinished"
+#define	SHARPENED_TIP "sharpened"
+#define CLOTH_TIP "cloth"
+#define CLOTH_TIP_BURNING "cloth_lit"
+#define SHARD_TIP "glass"
+#define BOTTLE_TIP "bottle"
+#define BONE_TIP "bone"
+#define BAMBOO_TIP "bamboo"
+#define IRON_TIP "iron"
+#define PLASTITANIUM_TIP "plastitanium"
+COOLDOWN_DECLARE(Burning_arrow)
+
 /obj/item/ammo_casing/caseless/arrow
 	name = "arrow of questionable material"
 	desc = "You shouldn't be seeing this arrow"
@@ -6,487 +18,329 @@
 	icon_state = "arrow"
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 4
-	throwforce = 3 //good luck hitting someone with the pointy end of the arrow
-	throw_speed = 3
-	//Is this an arrow shaft that can be turned into other arrows?
-	var/shaft_crafting = FALSE
-	var/cloth_result = null
-	var/shard_result = null
-	var/bottle_result = null
-	var/bone_result = null
-	var/bamboo_result = null
-	var/sharp_result = null
+	throwforce = 2
+	throw_speed = 2
+	///What the arrow is tipped with currently
+	var/arrow_state = UNFINISHED
+
+/obj/item/ammo_casing/caseless/arrow/Initialize(mapload)
+	. = ..()
+	var/obj/projectile/bullet/reusable/arrow/projectile_arrow = BB
+	projectile_arrow.arrow_state = UNFINISHED
 
 /obj/item/ammo_casing/caseless/arrow/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(istype(I, /obj/item/gun/ballistic/bow))
-		var/obj/item/gun/ballistic/bow/B = I
-		if(B.bowstring == null)
+		var/obj/item/gun/ballistic/bow/Bow = I
+
+		if(Bow.bowstring == null)
 			to_chat(user, "<span class='notice'>That bow has no bowstring!</span>")
 			return TRUE
 		else
-			B.magazine.attackby(src, user, params, 1)
+			Bow.magazine.attackby(src, user, params, 1)
 			to_chat(user, "<span class='notice'>You notch the arrow swiftly.</span>")
 			I.update_icon()
 			return TRUE
-	if(shaft_crafting)
+	if(arrow_state == UNFINISHED)
 		if(user.do_afters)
 			return TRUE
 		else
 			arrow_craft(I, user, params)
 			return TRUE
+	if(arrow_state == CLOTH_TIP && I.is_hot() > 900)
+		update_arrow_state(CLOTH_TIP_BURNING)
 
+/obj/item/ammo_casing/caseless/arrow/fire_act(exposed_temperature, exposed_volume)
+	if(arrow_state == CLOTH_TIP)
+		update_arrow_state(CLOTH_TIP_BURNING)
+	else
+		..()
+
+///Called when originally crafting the arrow
 /obj/item/ammo_casing/caseless/arrow/proc/arrow_craft(obj/item/I, mob/user, params)
+	//Wrap the object in cloth, making a flammable arrow!
 	if(istype(I, /obj/item/stack/sheet/cotton/cloth))
-		var/obj/item/stack/sheet/cotton/cloth/cloth = I
-		if(cloth.amount < 2) //Is there less than two sheets of cotton?
-			user.show_message("<span class='notice'>You need at least [2 - cloth.amount] unit\s of cloth before you can wrap it onto \the [src].</span>", MSG_VISUAL)
-			return FALSE
 		if(do_after(user, 1 SECONDS, I)) //Short do_after.
-			cloth.use(2) //Remove two cotton from the stack.
+			var/obj/item/stack/sheet/cloth = I
+			cloth.use(1)
 			user.show_message("<span class='notice'>You wrap \the [cloth.name] onto the [src].</span>", MSG_VISUAL)
-			new cloth_result(get_turf(src))
-			qdel(src)
+			update_arrow_state(CLOTH_TIP)
 			return TRUE
+
+	//Give the arrow a glass arrowhead. Not the best, but better than nothing!
 	else if(istype(I, /obj/item/shard))
 		if(do_after(user, 1 SECONDS, I))
-			user.show_message("<span class='notice'>You create a glass arrow with \the [I.name].</span>", MSG_VISUAL)
-			new shard_result(get_turf(src))
-			qdel(I)
-			qdel(src)
+			user.show_message("<span class='notice'>You fasten \the [I.name] to the end of the shaft.</span>", MSG_VISUAL)
+			update_arrow_state(SHARD_TIP, I)
 			return TRUE
-	else if(istype(I, /obj/item/reagent_containers/food/drinks/bottle))
+
+	//Give the arrow a bottle to splash reagents on the target hit by the arrow
+	else if(istype(I, /obj/item/reagent_containers/food/drinks) || istype(I, /obj/item/reagent_containers/glass/bottle))
 		if(do_after(user, 1 SECONDS, I))
-			user.show_message("<span class='notice'>You create a bottle arrow with \the [I.name].</span>", MSG_VISUAL)
-			new bottle_result(get_turf(src))
-			qdel(I)
-			qdel(src)
+			user.show_message("<span class='notice'>You attach \the [I.name] to the shaft.</span>", MSG_VISUAL)
+			update_arrow_state(BOTTLE_TIP, I)
 			return TRUE
+
+	//Give the arrow a hollowpoint bone arrowhead. Great for injecting reagents!
 	else if(istype(I, /obj/item/stack/sheet/bone))
-		var/obj/item/stack/sheet/bone/bone = I
-		if(bone.amount < 2)
-			user.show_message("<span class='notice'>You need at least [2 - bone.amount] bone to create a bone point arrow.</span>", MSG_VISUAL)
-			return FALSE
 		if(do_after(user, 1 SECONDS, I))
-			bone.use(2)
-			user.show_message("<span class='notice'>You create a bone point arrow.</span>", MSG_VISUAL)
-			new bone_result(get_turf(src))
-			qdel(src)
+			var/obj/item/stack/sheet/bone = I
+			bone.use(1)
+			user.show_message("<span class='notice'>You create a bone hollowpoint arrow.</span>", MSG_VISUAL)
+			update_arrow_state(BONE_TIP)
 			return TRUE
+
+	//Give the arrow a hollowpoint bamboo arrowhead. Great for injecting reagents, but not quite as powerful!
 	else if(istype(I, /obj/item/stack/sheet/bamboo))
-		var/obj/item/stack/sheet/bamboo/bamboo = I
-		if(bamboo.amount < 2)
-			user.show_message("<span class='notice'>You need at least [2 - bamboo.amount] bone to create a bamboo point arrow.</span>", MSG_VISUAL)
-			return FALSE
 		if(do_after(user, 1 SECONDS, I))
-			bamboo.use(2)
-			user.show_message("<span class='notice'>You create a bamboo point arrow.</span>", MSG_VISUAL)
-			new bamboo_result(get_turf(src))
-			qdel(src)
+			var/obj/item/stack/sheet/bamboo = I
+			bamboo.use(1)
+			user.show_message("<span class='notice'>You create a bamboo hollowpoint arrow.</span>", MSG_VISUAL)
+			update_arrow_state(BAMBOO_TIP)
 			return TRUE
+
+	else if(istype(I, /obj/item/stack/sheet/iron))
+		if(do_after(user, 2 SECONDS, I))
+			var/obj/item/stack/sheet/iron = I
+			iron.use(1)
+			user.show_message("<span class='notice'>You create an iron tipped arrow.</span>", MSG_VISUAL)
+			update_arrow_state(IRON_TIP)
+			return TRUE
+
+	else if(istype(I, /obj/item/stack/sheet/mineral/plastitanium))
+		if(do_after(user, 2 SECONDS, I))
+			var/obj/item/stack/sheet/plastitanium = I
+			plastitanium.use(1)
+			user.show_message("<span class='notice'>You create a plastitanium tipped arrow.</span>", MSG_VISUAL)
+			update_arrow_state(PLASTITANIUM_TIP)
+			return TRUE
+
+	//MUST be after glass shards, or the shard will sharpen an arrow
+	//Not attaching anything, but we can sharpen the end of whatever we are using to give it a decent embed chance!
 	else if(I.is_sharp())
-		if(do_after(user, 1 SECONDS, I))
+		if(do_after(user, 2 SECONDS, I))
 			user.show_message("<span class='notice'>You sharpen \the [name].</span>", MSG_VISUAL)
-			new sharp_result(get_turf(src))
 			playsound(src, 'sound/effects/footstep/hardclaw1.ogg', 50, 1)
-			qdel(src)
+			update_arrow_state(SHARPENED_TIP)
 			return TRUE
 
+///Updates overlay and appearance, description and stored projectile to match the new state
+/obj/item/ammo_casing/caseless/arrow/proc/update_arrow_state(new_state, attachment)
 
-///WOOD ARROWS///
+	//First update the stored projectile to reflect the new state
+	var/obj/projectile/bullet/reusable/arrow/projectile_arrow = BB
+	projectile_arrow.arrow_state = new_state
+	arrow_state = new_state
+
+	//skip generic damage/sound update if false
+	var/normal_arrow = TRUE
+
+	//And for everything else we need to know exactly what the state is, returning early for special states
+
+	switch(new_state)
+
+//BURNING ARROW (this one returns early, all the variables have already been set by cloth)
+		if(CLOTH_TIP_BURNING)
+			cut_overlay()
+			add_overlay("cloth_lit")
+			name = "flaming " + initial(name)
+			desc += " that has been set ablaze"
+			heat = 1500
+			projectile_arrow.burning = TRUE
+			light_system = MOVABLE_LIGHT
+			projectile_arrow.light_system = MOVABLE_LIGHT
+			light_range = 2
+			projectile_arrow.light_range = 2
+			light_power = 0.6
+			projectile_arrow.light_power = 0.6
+			light_on = TRUE
+			projectile_arrow.light_on = TRUE
+			light_color = LIGHT_COLOR_FIRE
+			projectile_arrow.light_color = LIGHT_COLOR_FIRE
+			return
+
+//SPECIAL ARROWS
+		if(UNFINISHED)
+			cut_overlay()
+			desc = initial(desc)
+			name = initial(name)
+			projectile_arrow.damage = initial(projectile_arrow.damage)
+			projectile_arrow.armour_penetration = initial(projectile_arrow.armour_penetration)
+			embedding = null
+			normal_arrow = FALSE
+
+		if(CLOTH_TIP)
+			add_overlay("cloth")
+			name = "padded " + name
+			desc += "\nThe end has been wrapped in soft, but flammable cloth"
+			projectile_arrow.damage = 1 //it's not totally harmless, but pretty close
+			normal_arrow = FALSE
+
+		if(BOTTLE_TIP)
+			var/obj/item/reagent_containers/bottle = attachment
+			create_reagents(bottle.volume, OPENCONTAINER)
+			bottle.reagents.trans_to(src, bottle.volume)
+			qdel(bottle)
+			add_overlay("bottle")
+			name = "bottle " + name
+			desc += "\nIt is being used to plug a[reagents?" bottle of something": "n empty bottle"]"
+			//Glass breaking sound when bottle breaks, standard blunt arrow hitting sound
+			normal_arrow = FALSE
+
+//STANDARD ARROWS
+		if(SHARPENED_TIP)
+			//No overlay for this one, sprite too small
+			name = "sharpened " + name
+			desc += "\nThe tip has been sharpened to a dangerous point"
+			embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 8, //likely to fall right out due to being easily removed
+				"pain_mult" = 0, //damage is dealt by the projectile on impact, not during the embed
+				"remove_pain_mult" = 0, //this arrow has no head and will smoothly pull straight out
+				"rip_time" = 1 SECONDS,
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 3,
+				"jostle_pain_mult" = 1,
+				"armour_block" = 40,
+				) //arrow has no head, and is missing some of the heft needed to get through proper armor
+
+		if(SHARD_TIP)
+			add_overlay("glass")
+			name = "glass-tipped " + name
+			desc += "\nThere is a nasty glass shard fastened to the end"
+			// no embedding for the arrow itself, a shard is broken off during the tryEmbed() proc below for this type of arrow
+
+		if(BAMBOO_TIP)
+			create_reagents(7, OPENCONTAINER)
+			add_overlay("bamboo")
+			name = "bamboo-tipped " + name
+			desc += "\nThe bamboo tip can inject up to [reagents.maximum_volume] units"
+			embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 6,
+				"pain_mult" = 0, //damage is dealt by the projectile on impact, not during the embed
+				"remove_pain_mult" = 1,
+				"rip_time" = 2 SECONDS,
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 3,
+				"jostle_pain_mult" = 1,
+				"armour_block" = 40) //Bamboo still doesn't have much heft to it. Bad against properly armored opponents
+
+		if(BONE_TIP)
+			create_reagents(5, OPENCONTAINER)
+			add_overlay("bone")
+			name = "bone-tipped " + name
+			desc += "\nThe bone tip can inject up to [reagents.maximum_volume] units"
+			embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 6,
+				"pain_mult" = 0, //damage is dealt by the projectile on impact, not during the embed
+				"remove_pain_mult" = 1,
+				"rip_time" = 2 SECONDS,
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 3,
+				"jostle_pain_mult" = 1,
+				"armour_block" = 80) //Bone is very dense and also good at piercing thick hides of lavaland creatures.
+
+		if(IRON_TIP)
+			add_overlay("iron")
+			name = "iron-tipped " + name
+			desc += "\nThe iron tip is dangerously sharp"
+			projectile_arrow.damage += 1 //+2 total
+			embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 3,
+				"pain_mult" = 0, //damage is dealt by the projectile on impact, not during the embed
+				"remove_pain_mult" = 1,
+				"rip_time" = 2 SECONDS,
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 4,
+				"jostle_pain_mult" = 1,
+				"armour_block" = 60) //Good heft, able to get through most standard armor
+
+		if(PLASTITANIUM_TIP)
+			add_overlay("plastitanium")
+			name = "broadhead " + name
+			desc += "\nThe tip of this arrow looks like it would cause especially nasty wounds"
+			projectile_arrow.damage += 1 //+2 total
+			embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 0, //This nasty arrowhead will not let the arrow fall out on its own and is much worse to rip out as well.
+				"pain_mult" = 0,
+				"remove_pain_mult" = 3,
+				"rip_time" = 3 SECONDS, //Standard embed time removal, where other arrows are faster
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 4,
+				"jostle_pain_mult" = 2,
+				"armour_block" = 80) //Plastitanium excells at piercing even the best armor
+	if(normal_arrow)
+		//Most states share the same sound/base damage
+		hitsound = 'sound/weapons/pierce.ogg'
+		projectile_arrow.damage *= 2
+		projectile_arrow.armour_penetration *= 10
+
+	//Reagents need to be reflected by the stored projectile as well
+	if(reagents)
+		projectile_arrow.create_reagents(reagents.maximum_volume, OPENCONTAINER)
+	//And finally we need to activate those embedding stats we may have added... Or remove them if they were lost.
+	updateEmbedding()
+
+///Called after an arrow has hit something solid to see if the arrow should break
+/obj/item/ammo_casing/caseless/arrow/proc/check_break(type)
+	switch(type)
+		if(BOTTLE_TIP)
+			new /obj/item/shard(loc)
+			playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 70, TRUE)
+			return UNFINISHED
+		if(CLOTH_TIP_BURNING)
+			playsound(loc, 'sound/weapons/fwoosh.ogg', 60, 0)
+			return UNFINISHED
+	return type
+
+/obj/item/ammo_casing/caseless/arrow/tryEmbed(atom/target, forced=FALSE, silent=FALSE)
+	if(arrow_state == SHARD_TIP)
+		update_arrow_state(UNFINISHED)
+		var/obj/item/shard/broken_tip = new(loc)
+		broken_tip.embedding = list(
+				"embed_chance" = 100,
+				"fall_chance" = 0,
+				"pain_mult" = 0,
+				"remove_pain_mult" = 5,
+				"rip_time" = 3 SECONDS,
+				"ignore_throwspeed_threshold" = TRUE,
+				"jostle_chance" = 8,
+				"jostle_pain_mult" = 2,
+				"armour_block" = 60)
+		broken_tip.updateEmbedding()
+		broken_tip.tryEmbed(target, forced, silent)
+		playsound(loc, 'sound/effects/hit_on_shattered_glass.ogg', 40, TRUE)
+	. = ..()
+
+///ARROW SHAFTS///
 
 /obj/item/ammo_casing/caseless/arrow/wood
-	name = "wooden arrow shaft"
-	desc = "An arrow shaft made out of wood. It can be fired as is, but not to great effect."
+	name = "wooden arrow"
+	desc = "A standard arrow made out of wood."
 	icon_state = "arrow_wood"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/wood
-	shaft_crafting = TRUE
-	cloth_result = /obj/item/ammo_casing/caseless/arrow/cloth
-	shard_result = /obj/item/ammo_casing/caseless/arrow/glass
-	bottle_result = /obj/item/ammo_casing/caseless/arrow/bottle
-	bone_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint
-	bamboo_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint
-	sharp_result = /obj/item/ammo_casing/caseless/arrow/wood/sharp
-
-/obj/item/ammo_casing/caseless/arrow/wood/sharp
-	name = "sharp wooden arrow shaft"
-	desc = "An arrow shaft made out of wood that has been sharpened to be used as an improvised arrow."
-	bleed_force = BLEED_SCRATCH
-	armour_penetration = 0
-	projectile_type = /obj/projectile/bullet/reusable/arrow/wood/sharp
-	embedding = list(embed_chance=100,
-	fall_chance = 1,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 3,
-	pain_mult = 0,
-	jostle_pain_mult = 0,
-	remove_pain_mult = 2,
-	rip_time = 5) //This will always embed and hardly falls on its own, but does not deal any damage once inside
-
-/obj/item/ammo_casing/caseless/arrow/cloth
-	name = "cloth arrow"
-	desc = "An arrow with a 'tip' wrapped in cloth. Being hit with this is like being hit with a high velocity pillow."
-	icon_state = "arrow_cloth"
-	heat = 1500
-	light_system = MOVABLE_LIGHT
-	light_range = 2
-	light_power = 0.6
-	light_on = FALSE
-	light_color = LIGHT_COLOR_FIRE
-	var/lit = FALSE
-	var/burnt = FALSE
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth
-
-/obj/item/ammo_casing/caseless/arrow/cloth/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(lit && M.IgniteMob())
-		message_admins("[ADMIN_LOOKUPFLW(user)] set [key_name_admin(M)] on fire with [src] at [AREACOORD(user)]")
-		log_game("[key_name(user)] set [key_name(M)] on fire with [src] at [AREACOORD(user)]")
-
-/obj/item/ammo_casing/caseless/arrow/cloth/fire_act(exposed_temperature, exposed_volume)
-	ignite()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/attackby(obj/item/I, mob/user, params)
-	. = ..()
-	if(I.is_hot() > 900)
-		ignite()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/is_hot()
-	return lit * heat
-
-/obj/item/ammo_casing/caseless/arrow/cloth/extinguish()
-	burnout()
-	return ..()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/proc/ignite()
-	var/obj/projectile/bullet/reusable/arrow/cloth/arrow = BB
-	if(!lit && !burnt)
-		playsound(src, "sound/items/match_strike.ogg", 15, TRUE)
-		lit = TRUE
-		damtype = BURN
-		arrow.lit = TRUE
-		force += 2
-		hitsound = 'sound/items/welder.ogg'
-		name = "lit [initial(name)]"
-		desc = "An arrow with a 'tip' wrapped in cloth. Being hit with this is like being hit with a high velocity pillow. Except its on fire. Fear the pillow."
-		attack_verb_continuous = list("burnt","singed")
-		set_light_on(lit)
-	update_overlays()
-	arrow.update_overlays()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/proc/burnout()
-	var/obj/projectile/bullet/reusable/arrow/cloth/arrow = BB
-	if(lit)
-		lit = FALSE
-		burnt = TRUE
-		arrow.burnt = TRUE
-		arrow.lit = FALSE
-		damtype = initial(damtype)
-		force = initial(force)
-		name = "burnt [initial(name)]"
-		desc = "An arrow with a 'tip' wrapped in burnt cloth. Being hit with this is like being hit with a high velocity pillow. Full of ash."
-		set_light_on(lit)
-	update_overlays()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/update_overlays()
-	. = .. ()
-	cut_overlays()
-	if(lit)
-		add_overlay("[initial(icon_state)]_lit")
-	if(burnt)
-		add_overlay("[initial(icon_state)]_burnt")
-
-/obj/item/ammo_casing/caseless/arrow/cloth/burnt
-	name = "burnt cloth arrow"
-	desc = "An arrow with a 'tip' wrapped in burnt cloth. Being hit with this is like being hit with a high velocity pillow. Full of ash."
-	icon_state = "arrow_cloth_burnt"
-	burnt = TRUE
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth/burnt
-
-/obj/item/ammo_casing/caseless/arrow/cloth/burnt/attackby(obj/item/I, mob/user)
-	. = ..()
-	if(replace(I, user))
-		return
-	return ..()
-
-/obj/item/ammo_casing/caseless/arrow/cloth/burnt/proc/replace(obj/item/stack/sheet/cotton/cloth/I, mob/user) //Proc for replacing the cotton on the arrow.
-	if(!istype(I)) //Were we clicked on by a sheet of cotton?
-		return FALSE
-	if(I.amount < 2) //Is there less than two sheets of cotton?
-		user.show_message("<span class='notice'>You need at least [2 - I.amount] unit\s of cloth before you can wrap \the [I] onto \the [src].</span>", MSG_VISUAL)
-		return FALSE
-	if(do_after(user, 1 SECONDS, I)) //Short do_after.
-		I.use(2) //Remove two cotton from the stack.
-		user.show_message("<span class='notice'>You wrap \the [I.name] onto the [src].</span>", MSG_VISUAL)
-		new cloth_result(get_turf(src)) //New arrow.
-		qdel(src) //Delete the old, burnt arrow.
-		return TRUE
-	return FALSE
-
-/obj/item/ammo_casing/caseless/arrow/glass
-	name = "glass arrow"
-	desc = "A crude 'arrow' with a glass shard for a tip. Upon impact, the glass will inevitably fall out of the shaft and remain lodged on the targets flesh."
-	icon_state = "arrow_glass"
-	sharpness = IS_SHARP
-	bleed_force = BLEED_SURFACE
-	attack_verb_continuous = list("stabbed", "slashed", "sliced", "cut")
-	hitsound = 'sound/weapons/bladeslice.ogg'
-	projectile_type = /obj/projectile/bullet/reusable/arrow/glass
-	embedding = list(embed_chance=100,
-	fall_chance = 10,
-	jostle_chance = 35,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 0.25,
-	jostle_pain_mult = 2,
-	remove_pain_mult = 0.5,
-	rip_time = 5) //the small shard will be lodged in your chest cavity hurting you with every 3 steps until it falls off
-
-/obj/item/ammo_casing/caseless/arrow/bottle
-	name = "bottle arrow"
-	desc = "A tiny bottle tied with string to an arrow shaft. Cute, if not filled with acid."
-	icon_state = "arrow_bottle"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bottle
-	var/reagent_amount = 30
-
-/obj/item/ammo_casing/caseless/arrow/bottle/Initialize(mapload)
-	. = ..()
-	create_reagents(reagent_amount, OPENCONTAINER)
-
-/obj/item/ammo_casing/caseless/arrow/bottle/on_reagent_change(changetype)
-	. = ..()
-	update_icon()
-
-/obj/item/ammo_casing/caseless/arrow/bottle/update_icon()
-	. = ..()
-	cut_overlays()
-	add_overlay("arrow_bottle_0")
-	if(reagents)
-		if(reagents.total_volume == 10)
-			add_overlay("arrow_bottle_10")
-		else if(reagents.total_volume == 20)
-			add_overlay("arrow_bottle_20")
-		else if(reagents.total_volume == 30)
-			add_overlay("arrow_bottle_30")
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint
-	name = "bone point wooden arrow"
-	desc = "An arrow with an hollow bone point. Able to inject its contects onto its target."
-	icon_state = "arrow_bonepoint"
-	embedding = list(embed_chance=100,
-	fall_chance = 5,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 1,
-	jostle_pain_mult = 1,
-	remove_pain_mult = 2,
-	rip_time = 5)
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint
-	var/reagent_amount = 5
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/Initialize(mapload)
-	. = ..()
-	create_reagents(reagent_amount, OPENCONTAINER)
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/on_reagent_change(changetype)
-	. = ..()
-	update_icon()
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/update_icon()
-	. = ..()
-	cut_overlays()
-	if(reagents)
-		if(reagents.total_volume > 0)
-			add_overlay("hollowpoint_full")
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint
-	name = "bamboo point wooden arrow"
-	desc = "An arrow with an hollow bamboo point. Able to inject its contects onto its target."
-	icon_state = "arrow_bamboopoint"
-	embedding = list(embed_chance=100,
-	fall_chance = 5,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 1,
-	jostle_pain_mult = 1,
-	remove_pain_mult = 0,
-	rip_time = 2)
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint
-	reagent_amount = 7
-
-///BONE ARROWS///
-
-/obj/item/ammo_casing/caseless/arrow/bone
-	name = "bone arrow shaft"
-	desc = "An arrow shaft carved out of bone. Arrows made with this material will generally be more painful but cause less bleeding."
-	icon_state = "bonearrow"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bone
-	shaft_crafting = TRUE
-	cloth_result = /obj/item/ammo_casing/caseless/arrow/cloth/bone
-	shard_result = /obj/item/ammo_casing/caseless/arrow/glass/bone
-	bottle_result = /obj/item/ammo_casing/caseless/arrow/bottle/bone
-	bone_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bone
-	bamboo_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bone
-	sharp_result = /obj/item/ammo_casing/caseless/arrow/bone/sharp
-
-/obj/item/ammo_casing/caseless/arrow/bone/sharp
-	name = "sharp bone arrow shaft"
-	desc = "A sharpened bone arrow shaft. Able to piece flesh and remain lodged, causing pain until removed."
-	bleed_force = BLEED_TINY
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bone/sharp
-	embedding = list(embed_chance=100,
-	fall_chance = 5,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 1,
-	jostle_pain_mult = 1,
-	remove_pain_mult = 2,
-	rip_time = 5) //I don't know if you ever saw something poorly carved out of bone, but let me tell you, its got worse splinters than wood. Now imagine that in your liver.
-
-/obj/item/ammo_casing/caseless/arrow/cloth/bone
-	name = "cloth bone arrow"
-	icon_state = "bonearrow_cloth"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth/bone
-
-/obj/item/ammo_casing/caseless/arrow/cloth/burnt/bone
-	name = "burnt cloth bone arrow"
-	icon_state = "bonearrow_cloth_burnt"
-	burnt = TRUE
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth/burnt/bone
-
-/obj/item/ammo_casing/caseless/arrow/glass/bone
-	name = "bone glass arrow"
-	icon_state = "bonearrow_glass"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/glass/bone
-
-/obj/item/ammo_casing/caseless/arrow/bottle/bone
-	name = "bone bottle arrow"
-	icon_state = "bonearrow_bottle"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bottle/bone
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/bone
-	name = "bone point arrow"
-	icon_state = "bonearrow_bonepoint"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bone
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bone
-	name = "bamboo point bone arrow"
-	icon_state = "bonearrow_bamboopoint"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bone
-
-///BAMBOO ARROWS///
 
 /obj/item/ammo_casing/caseless/arrow/bamboo
-	name = "bamboo arrow shaft"
-	desc = "An arrow shaft made out of bamboo. It is suitable to make lighter arrows that pierce their target better than other materials at the cost of damage."
-	icon_state = "bambooarrow"
+	name = "bamboo arrow"
+	desc = "An arrow made out of bamboo, just a bit lighter than normal wood"
+	icon_state = "arrow_bamboo"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/bamboo
-	shaft_crafting = TRUE
-	cloth_result = /obj/item/ammo_casing/caseless/arrow/cloth/bamboo
-	shard_result = /obj/item/ammo_casing/caseless/arrow/glass/bamboo
-	bottle_result = /obj/item/ammo_casing/caseless/arrow/bottle/bamboo
-	bone_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboo
-	bamboo_result = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bamboo/
-	sharp_result = /obj/item/ammo_casing/caseless/arrow/bamboo/sharp
 
-/obj/item/ammo_casing/caseless/arrow/bamboo/sharp
-	name = "sharp bamboo arrow shaft"
-	desc = "A sharpened bamboo arrow shaft. Able to piece flesh and remain lodged, causing pain until removed."
-	bleed_force = BLEED_SURFACE
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bamboo/sharp
-	embedding = list(embed_chance=100,
-	fall_chance = 0,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 0.5,
-	jostle_pain_mult = 1,
-	remove_pain_mult = 1,
-	rip_time = 1)
+/obj/item/ammo_casing/caseless/arrow/bone
+	name = "bone arrow"
+	desc = "An arrow carved out of bone, denser than wooden arrows."
+	icon_state = "arrow_bone"
+	projectile_type = /obj/projectile/bullet/reusable/arrow/bone
 
-/obj/item/ammo_casing/caseless/arrow/cloth/bamboo
-	name = "cloth bamboo arrow"
-	icon_state = "bambooarrow_cloth"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/cloth/burnt/bamboo
-	name = "burnt cloth bamboo arrow"
-	icon_state = "bambooarrow_cloth_burnt"
-	burnt = TRUE
-	projectile_type = /obj/projectile/bullet/reusable/arrow/cloth/burnt/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/glass/bamboo
-	name = "glass bamboo arrow"
-	icon_state = "bambooarrow_glass"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/glass/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/bottle/bamboo
-	name = "bamboo bottle arrow"
-	icon_state = "bambooarrow_bottle"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/bottle/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboo
-	name = "bamboo point arrow"
-	icon_state = "bambooarrow_bonepoint"
-	embedding = list(embed_chance=100,
-	fall_chance = 0,
-	jostle_chance = 10,
-	ignore_throwspeed_threshold = FALSE,
-	pain_stam_pct = 1,
-	pain_mult = 0.5,
-	jostle_pain_mult = 1,
-	remove_pain_mult = 1,
-	rip_time = 1)
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bamboo
-	name = "bamboo point arrow"
-	icon_state = "bambooarrow_bamboopoint"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bamboo
-
-/obj/item/ammo_casing/caseless/arrow/sm //Adminbus for now
-	name = "SM arrow"
-	desc = "Weaponized SM. Fear it."
-	icon_state = "arrow_sm"
-	force = 0
-	throwforce = 0
-	light_system = MOVABLE_LIGHT
-	light_range = 2
-	light_power = 0.8
-	light_on = TRUE
-	light_color = LIGHT_COLOR_HOLY_MAGIC
-	var/shard = new /obj/machinery/power/supermatter_crystal/shard //This was meant to be craftable, using the shard but it isnt for now
-	projectile_type = /obj/projectile/bullet/reusable/arrow/sm
-
-/obj/item/ammo_casing/caseless/arrow/sm/update_icon()
-	. = ..()
-	cut_overlays()
-	if(shard)
-		add_overlay("arrow_sm_shard")
-
-/obj/structure/closet/arrows //Test closet
-
-/obj/structure/closet/arrows/PopulateContents()
-	new /obj/item/gun/ballistic/bow/syndicate(src)
-	new /obj/item/gun/ballistic/bow/pvc(src)
-	new /obj/item/gun/ballistic/bow(src)
-	new /obj/item/ammo_casing/caseless/arrow/cloth(src)
-	new /obj/item/ammo_casing/caseless/arrow/cloth/bamboo(src)
-	new /obj/item/ammo_casing/caseless/arrow/glass(src)
-	new /obj/item/ammo_casing/caseless/arrow/glass/bone(src)
-	new /obj/item/lighter(src)
-	new /obj/item/stack/sheet/cotton/cloth/fifty(src)
-	new /obj/item/stack/sheet/wood/fifty(src)
-	..()
-
-/obj/item/ammo_casing/caseless/arrow/ash
-	name = "ashen arrow"
-	desc = "An arrow made from wood, hardened by fire"
-	icon_state = "ashenarrow"
-	projectile_type = /obj/projectile/bullet/reusable/arrow/ash
+/obj/item/ammo_casing/caseless/arrow/plastitanium
+	name = "plastitanium arrow"
+	desc = "An arrow formed from a very sturdy but lightweight alloy"
+	icon_state = "arrow_plastitanium"
+	projectile_type = /obj/projectile/bullet/reusable/arrow/plastitanium
 
 /obj/item/ammo_casing/caseless/arrow/bronze
 	name = "bronze arrow"
@@ -494,3 +348,13 @@
 	icon_state = "bronzearrow"
 	projectile_type = /obj/projectile/bullet/reusable/arrow/bronze
 
+#undef UNFINISHED
+#undef SHARPENED_TIP
+#undef CLOTH_TIP
+#undef CLOTH_TIP_BURNING
+#undef SHARD_TIP
+#undef BOTTLE_TIP
+#undef BONE_TIP
+#undef BAMBOO_TIP
+#undef IRON_TIP
+#undef PLASTITANIUM_TIP

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -22,6 +22,8 @@ COOLDOWN_DECLARE(Burning_arrow)
 	throw_speed = 2
 	///What the arrow is tipped with currently
 	var/arrow_state = UNFINISHED
+	//This is updated when attaching a head
+	bleed_force = 0
 
 /obj/item/ammo_casing/caseless/arrow/Initialize(mapload)
 	. = ..()
@@ -278,6 +280,7 @@ COOLDOWN_DECLARE(Burning_arrow)
 		hitsound = 'sound/weapons/pierce.ogg'
 		projectile_arrow.damage *= 2
 		projectile_arrow.armour_penetration *= 10
+		bleed_force = BLEED_DEEP_WOUND
 
 	//Reagents need to be reflected by the stored projectile as well
 	if(reagents)
@@ -346,6 +349,7 @@ COOLDOWN_DECLARE(Burning_arrow)
 	name = "bronze arrow"
 	desc = "An arrow made from wood. tipped with bronze."
 	icon_state = "bronzearrow"
+	bleed_force = BLEED_DEEP_WOUND
 	projectile_type = /obj/projectile/bullet/reusable/arrow/bronze
 
 #undef UNFINISHED

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -101,11 +101,9 @@
 		to_chat(user, "<span class='notice'>You notch the arrow.</span>")
 		update_icon()
 	if(I.is_hot() > 900 && get_ammo()) //You can set a cloth arrow alight while it is notched
-		var/obj/item/ammo_casing/caseless/arrow/cloth/AC = magazine.get_round(1)
-		if(istype(AC, /obj/item/ammo_casing/caseless/arrow/cloth))
-			if(!AC.lit && !AC.burnt)
-				AC.ignite()
-				update_icon()
+		var/obj/item/ammo_casing/caseless/arrow/AC = magazine.get_round(1)
+		AC.attackby(I, user, params)
+	..()
 
 /obj/item/gun/ballistic/bow/proc/string_update(obj/item/I, mob/user, params)
 	var/obj/item/weaponcrafting/attachment/primary/S = I

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -154,6 +154,9 @@
 	///If TRUE, hit mobs even if they're on the floor and not our target
 	var/hit_stunned_targets = FALSE
 
+	/// The last thing the projectile force-pierced due to holopara shenanigans.
+	var/atom/movable/last_holopara_pierce
+
 /obj/projectile/Initialize(mapload)
 	. = ..()
 	decayedRange = range

--- a/code/modules/projectiles/projectile/reusable/_reusable.dm
+++ b/code/modules/projectiles/projectile/reusable/_reusable.dm
@@ -3,16 +3,11 @@
 	desc = "How do you even reuse a bullet?"
 	var/ammo_type = /obj/item/ammo_casing/caseless
 	var/dropped = FALSE
-	//This actually checks if you want a copy of this projectile to spawn on hit. If this is set to false, but it actually embeds the only thing thats gonna happen is it will drop twice.
-	var/embedds = FALSE
 	impact_effect_type = null
 
 /obj/projectile/bullet/reusable/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-	if(!embedds)
-		handle_drop()
-	else if(embedds && !iscarbon(target))
-		handle_drop()
+	handle_drop()
 
 /obj/projectile/bullet/reusable/on_range()
 	handle_drop()

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -1,332 +1,88 @@
 /obj/projectile/bullet/reusable/arrow
-	name = "Wooden arrow"
+	name = "formless Arrow"
 	desc = "Woosh!"
 	icon_state = "arrow"
-	damage = 20
-	armour_penetration = -20
-	embedds = TRUE
+	damage = 10
+	armour_penetration = 0
 	ammo_type = /obj/item/ammo_casing/caseless/arrow
+	//passed on from the ammo_type when processed, so that it can be passed back to the ammo_type when dropped
+	var/arrow_state = "unfinished"
+	var/burning
 
-///WOOD ARROWS///
+/obj/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
+	//check if embedding and reagent logic
+	var/obj/item/ammo_casing/caseless/arrow/obj_arrow = convert_proj_to_obj()
+
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		var/obj/item/bodypart/B = C.get_bodypart(def_zone)
+		if(obj_arrow.tryEmbed(B))
+			if(reagents) //if we embed successfully, inject all of our reagents
+				reagents.reaction(C, INJECT, reagents.total_volume)
+				reagents.trans_to(C, reagents.total_volume)
+		if(burning)
+			var/mob/living/carbon/M = target
+			M.adjust_fire_stacks(2)
+			M.IgniteMob()
+
+	if(reagents?.total_volume)//In case we didn't inject, reagents will splash out here
+		reagents.reaction(target, TOUCH, reagents.total_volume)
+		visible_message("<span class='notice'>[src] spills its contents all over [target].</span>")
+
+	if (isanimal(target)) //Arrows are very effective against simplemobs
+		damage *= 2
+
+	//standard projectile behavior takes over now
+	. = ..()
+
+//Re-creates the ammo_type when needed for embedding or dropping
+/obj/projectile/bullet/reusable/arrow/proc/convert_proj_to_obj()
+	dropped = TRUE
+	var/obj/item/ammo_casing/caseless/arrow/dropped_arrow = new ammo_type
+	dropped_arrow.forceMove(loc)
+	dropped_arrow.update_arrow_state(dropped_arrow.check_break(arrow_state)) //Update the dropped arrow type by breaking it if necessary, also resets reagents
+	return dropped_arrow
+
+//override this proc entirely, we handle it unique to other reusables
+/obj/projectile/bullet/reusable/arrow/handle_drop()
+	if(dropped)
+		return
+	convert_proj_to_obj()
 
 /obj/projectile/bullet/reusable/arrow/wood
-	name = "wooden arrow shaft"
+	name = "wooden arrow"
 	icon_state = "arrow_wood"
-	damage = 10
-	bleed_force = BLEED_TINY
+	damage = 9.5 //19 when finished
+	bleed_force = 0
 	armour_penetration = 0
-	embedds = FALSE
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
 	hitsound = 'sound/effects/hit_punch.ogg'
-
-/obj/projectile/bullet/reusable/arrow/wood/sharp
-	name = "sharp wood arrow shaft"
-	damage = 15
-	bleed_force = BLEED_CUT
-	embedds = TRUE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood/sharp
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/wood/sharp
-	hitsound = 'sound/weapons/pierce.ogg'
-
-/obj/projectile/bullet/reusable/arrow/cloth
-	name = "cloth arrow"
-	icon_state = "arrow_cloth"
-	damage = 10
-	bleed_force = 0
-	armour_penetration = 10  //blunt force trauma
-	embedds = FALSE
-	light_system = MOVABLE_LIGHT
-	light_range = 3
-	light_power = 0.5
-	light_on = FALSE
-	light_color = LIGHT_COLOR_FIRE
-	var/heat = 1500
-	var/lit = FALSE
-	var/burnt = FALSE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth
-	hitsound = 'sound/effects/hit_punch.ogg'
-
-/obj/projectile/bullet/reusable/arrow/cloth/fire()
-	if(lit)
-		damage_type = BURN
-		damage = 10
-		set_light_on(lit)
-		update_overlays()
-	else if(burnt)
-		damage_type = initial(damage_type)
-		damage = initial(damage)
-		hitsound = initial(hitsound)
-		update_overlays()
-	. = .. ()
-
-/obj/projectile/bullet/reusable/arrow/cloth/on_hit(atom/target, blocked)
-	if(lit)
-		lit = FALSE
-		burnt = TRUE
-		if(iscarbon(target) && !blocked)
-			var/mob/living/carbon/M = target
-			M.IgniteMob()
-		if(name == "cloth arrow")
-			ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt
-		else if(name == "bone cloth arrow")
-			ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt/bone
-		else if(name == "bamboo cloth arrow")
-			ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt/bamboo
-	. = ..()
-
-/obj/projectile/bullet/reusable/arrow/cloth/update_overlays()
-	. = .. ()
-	cut_overlays()
-	if(lit)
-		add_overlay("[initial(icon_state)]_lit")
-	else if(burnt)
-		add_overlay("[initial(icon_state)]_burnt")
-
-
-/obj/projectile/bullet/reusable/arrow/cloth/burnt
-	name = "burnt cloth arrow"
-	icon_state = "arrow_cloth_burnt"
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt
-
-/obj/projectile/bullet/reusable/arrow/glass
-	name = "glass arrow"
-	icon_state = "arrow_glass"
-	damage = 5
-	embedds = FALSE
-	armour_penetration = 5
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood //The glass breaks on impact
-	shrapnel_type = /obj/item/shard
-	hitsound = 'sound/effects/glass_step.ogg'
-
-/obj/projectile/bullet/reusable/arrow/bottle
-	name = "bottle arrow"
-	icon_state = "arrow_bottle"
-	damage = 5
-	armour_penetration = 0
-	embedds = FALSE
-	hitsound = 'sound/effects/hit_punch.ogg'
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
-
-/obj/projectile/bullet/reusable/arrow/bottle/Initialize(mapload)
-	. = ..()
-	create_reagents(30, NO_REACT)
-
-/obj/projectile/bullet/reusable/arrow/bottle/on_hit(atom/target, blocked)
-	. = ..()
-	chem_splash(get_turf(src), 1, list(reagents))
-	playsound(src, "shatter", 75, 1)
-	new /obj/item/broken_bottle(get_turf(src))
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint
-	name = "bone point wooden arrow"
-	icon_state = "arrow_bonepoint"
-	damage = 15
-	armour_penetration = 5
-	var/reagent_amount = 5 //This has to match the ammo casing value
-	embedds = TRUE
-	bleed_force = BLEED_CUT
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/Initialize(mapload)
-	. = ..()
-	create_reagents(5, AMOUNT_VISIBLE)
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/on_hit(atom/target, blocked)
-	var/mob/living/L
-	if(!istype(target, L))
-		return ..()
-	reagents.reaction(target,INJECT,reagent_amount)
-	reagents.trans_to(target,reagent_amount, 1, FALSE)
-	return ..()
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint
-	name = "bamboo point wooden arrow"
-	icon_state = "arrow_bamboopoint"
-	damage = 10
-	armour_penetration = 5
-	reagent_amount = 7
-	embedds = TRUE
-	bleed_force = BLEED_CUT
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint
-
-
-///BONE ARROWS///
-
-/obj/projectile/bullet/reusable/arrow/bone
-	name = "bone arrow shaft"
-	damage = 12
-	bleed_force = 0
-	armour_penetration = 10
-	embedds = FALSE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
-	hitsound = 'sound/effects/hit_punch.ogg'
-
-/obj/projectile/bullet/reusable/arrow/bone/sharp
-	name = "sharp bone arrow shaft"
-	damage = 17
-	bleed_force = BLEED_SCRATCH
-	embedds = TRUE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood/sharp
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/wood/sharp
-	hitsound = 'sound/weapons/pierce.ogg'
-
-/obj/projectile/bullet/reusable/arrow/cloth/bone
-	name = "bone cloth arrow"
-	damage = 12
-	bleed_force = 0
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/bone
-
-/obj/projectile/bullet/reusable/arrow/cloth/burnt/bone
-	name = "burnt bone cloth arrow"
-	bleed_force = 0
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt/bone
-
-/obj/projectile/bullet/reusable/arrow/glass/bone
-	name = "glass bone arrow"
-	damage = 7
-	bleed_force = BLEED_SURFACE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
-
-/obj/projectile/bullet/reusable/arrow/bottle/bone
-	name = "bone bottle arrow"
-	damage = 7
-	bleed_force = 0
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/bone
-	name = "bone point arrow"
-	damage = 17
-	armour_penetration = 5
-	bleed_force = BLEED_SURFACE
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bone
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bone
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bone
-	name = "bamboo point bone arrow"
-	damage = 12
-	armour_penetration = 10
-	embedds = TRUE
-	bleed_force = BLEED_SURFACE
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bone
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bone
-
-///BAMBOO ARROWS///
 
 /obj/projectile/bullet/reusable/arrow/bamboo
-	name = "bamboo arrow shaft"
-	damage = 8
+	name = "bamboo arrow"
+	damage = 8.5 //17 when finished
+	speed = 0.7
 	bleed_force = 0
-	armour_penetration = 10
-	embedds = FALSE
+	armour_penetration = 0
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bamboo
 	hitsound = 'sound/effects/hit_punch.ogg'
 
-/obj/projectile/bullet/reusable/arrow/bamboo/sharp
-	name = "sharp bamboo arrow shaft"
-	damage = 13
-	bleed_force = BLEED_CUT
-	embedds = TRUE
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/bamboo/sharp
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/bamboo/sharp
-	hitsound = 'sound/weapons/pierce.ogg'
-
-/obj/projectile/bullet/reusable/arrow/cloth/bamboo
-	name = "bamboo cloth arrow"
-	damage = 8
-	armour_penetration = 20
+/obj/projectile/bullet/reusable/arrow/bone
+	name = "bone arrow"
+	damage = 10 //20 when finished without bonus
 	bleed_force = 0
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/bamboo
-
-/obj/projectile/bullet/reusable/arrow/cloth/burnt/bamboo
-	name = "burnt bamboo cloth arrow"
-	bleed_force = 0
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/cloth/burnt/bamboo
-
-/obj/projectile/bullet/reusable/arrow/glass/bamboo
-	name = "glass bamboo arrow"
-	damage = 3
-	bleed_force = BLEED_DEEP_WOUND
-	ammo_type = /obj/projectile/bullet/reusable/arrow/bamboo
-
-/obj/projectile/bullet/reusable/arrow/bottle/bamboo
-	name = "bone bottle arrow"
-	damage = 3
-	bleed_force = BLEED_TINY
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/bamboo
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/bamboo
-	name = "bone point bamboo arrow"
-	damage = 8
 	armour_penetration = 10
-	bleed_force = BLEED_SURFACE
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboo
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboo
-
-/obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bamboo
-	name = "bamboo point arrow"
-	damage = 8
-	armour_penetration = 15
-	embedds = TRUE
-	bleed_force = BLEED_CUT
-	ammo_type = /obj/projectile/bullet/reusable/arrow/hollowpoint/bamboopoint/bamboo
-	shrapnel_type = /obj/item/ammo_casing/caseless/arrow/hollowpoint/bamboopoint/bamboo
-
-/obj/projectile/bullet/reusable/arrow/sm
-	name = "SM arrow"
-	desc = "Weaponized SM. Fear it."
-	icon_state = "arrow_sm"
-	damage = 0
-	armour_penetration = 0
-	light_system = MOVABLE_LIGHT
-	light_range = 3
-	light_power = 1
-	light_on = TRUE
-	light_color = LIGHT_COLOR_HOLY_MAGIC
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/sm
-
-/obj/projectile/bullet/reusable/arrow/sm/on_hit(atom/target, blocked)
-	. = ..()
-	if(istype(target, /mob/living/carbon))
-		var/mob/living/carbon/T = target
-		if(!blocked)
-			consume(T)
-		else
-			handle_drop()
-
-
-/obj/projectile/bullet/reusable/arrow/sm/proc/consume(atom/movable/AM, mob/user)
-	if(ismob(AM))
-		var/mob/victim = AM
-		victim.investigate_log("has been dusted by [src].", INVESTIGATE_DEATHS)
-		victim.dust()
-		message_admins("[src] has consumed [key_name_admin(victim)] [ADMIN_JMP(src)].")
-		investigate_log("has consumed [key_name(victim)].", "supermatter")
-	else
-		investigate_log("has consumed [AM].", "supermatter")
-		qdel(AM)
-	if(user)
-		user.visible_message("<span class='danger'>As [AM] is hit with with \the [src], both flash into dust and silence fills the room...</span>",\
-			"<span class='italics'>Everything suddenly goes silent.</span>")
-		user.investigate_log("has been dusted by [src].", INVESTIGATE_DEATHS)
-		user.dust()
-	radiation_pulse(src, 500, 2)
-	playsound(src, 'sound/effects/supermatter.ogg', 75, 1)
-	QDEL_NULL(src)
-
-/obj/projectile/bullet/reusable/arrow/ash
-	name = "Ashen arrow"
-	desc = "Fire Hardened arrow."
-	damage = 25
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/ash
-
-/obj/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
-	name = "Bone arrow"
-	desc = "An arrow made from bone and sinew."
-	damage = 25
-	armour_penetration = 40
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
+	hitsound = 'sound/effects/hit_punch.ogg'
+
+/obj/projectile/bullet/reusable/arrow/plastitanium
+	name = "plastitanium arrow"
+	damage = 10 //20 when finished without bonus
+	speed = 0.9
+	bleed_force = 0
+	armour_penetration = 20
+	ammo_type = /obj/item/ammo_casing/caseless/arrow/plastitanium
+	hitsound = 'sound/effects/hit_punch.ogg'
 
 /obj/projectile/bullet/reusable/arrow/bronze
 	name = "Bronze arrow"
@@ -334,3 +90,4 @@
 	damage = 20
 	armour_penetration = 10
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bronze
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Greatly reduced the types of arrows defined
  * There are now only Wooden, Bamboo, Bone and Plastitanium arrows
* Adds crafting recipe for Plastitanium arrow
* Modularizes arrow heads/attachments so that they are stored within the arrow and transferred to the projectile
* Removed supermatter arrow
* Removed "burnt" arrow, instead favoring the flaming arrow dropping as an unfinished arrow. Arrows that are on fire do not have a timer associated with them and will burn indefinitely until fired.

## What still needs to be done
* Arrow sprites when loaded into the bow are broken, these sprites will need to be updated to match the same naming as the plain arrow item now. Overlays may be used to assist in this. 
* Arrows that are on fire (and by extension the projectile) do not actually emit light. I couldn't be assed to fix this one and it's up to you to resolve this one
* Bronze arrows potentially need to be generated by their bow, I recommend doing it when attempting to draw the string so that other arrows may also be used with the clockwork bow at will, but trying to draw the bow with no arrow materializes a bronze one. 
