### PR TITLE
Fixes the three guns that were overlooked

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -363,38 +363,6 @@ CREATION_TEST_IGNORE_SUBTYPES(/obj/item/stock_parts/cell)
 	chargerate_divide = 100
 	maxcharge = 20 KILOWATT
 
-/obj/item/stock_parts/cell/emproof
-	name = "\improper EMP-proof cell"
-	desc = "An EMP-proof cell."
-	maxcharge = 0.5 KILOWATT
-	rating = 3
-
-/obj/item/stock_parts/cell/emproof/empty/Initialize(mapload)
-	. = ..()
-	charge = 0
-	update_appearance()
-
-/obj/item/stock_parts/cell/emproof/empty/ComponentInitialize()
-	. = ..()
-	AddElement(/datum/element/empprotection, EMP_PROTECT_SELF)
-
-/obj/item/stock_parts/cell/emproof/corrupt()
-	return
-
-/obj/item/stock_parts/cell/beam_rifle
-	name = "beam rifle capacitor"
-	desc = "A high powered capacitor that can provide huge amounts of energy in an instant."
-	maxcharge = 50 KILOWATT
-
-/obj/item/stock_parts/cell/beam_rifle/corrupt()
-	return
-
-/obj/item/stock_parts/cell/beam_rifle/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	charge = clamp((charge-(1000/severity)),0,maxcharge)
-
 /obj/item/stock_parts/cell/emergency_light
 	name = "miniature power cell"
 	desc = "A tiny power cell with a very low power capacity. Used in light fixtures to power them in the event of an outage."

--- a/code/modules/projectiles/guns/energy/recharge.dm
+++ b/code/modules/projectiles/guns/energy/recharge.dm
@@ -6,7 +6,7 @@
 	base_icon_state = "kineticgun"
 	desc = "A self recharging gun. Holds one shot at a time."
 	automatic_charge_overlays = FALSE
-	cell_type = /obj/item/stock_parts/cell/emproof
+	gun_charge = 5000 WATT
 	/// If set to something, instead of an overlay, sets the icon_state directly.
 	var/no_charge_state
 	/// Does it hold charge when not put away?

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -145,7 +145,7 @@
 			to_chat(user, span_notice("You try to insert [I] into [src], but it's fully charged.")) //my cell is round and full
 			return
 		I.use(1)
-		cell.give(500 *charge_multiplier)
+		cell.give(5 KILOWATT *charge_multiplier)
 		to_chat(user, span_notice("You insert [I] in [src], recharging it."))
 	else
 		..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -314,7 +314,7 @@
 	icon_state = "freezegun"
 	desc = "A gun that changes temperatures."
 	ammo_type = list(/obj/item/ammo_casing/energy/temp, /obj/item/ammo_casing/energy/temp/hot)
-	cell_type = "/obj/item/stock_parts/cell/high"
+	gun_charge = 100 KILOWATT
 	automatic = 1
 	fire_rate = 4
 	pin = null

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -27,7 +27,7 @@
 	weapon_weight = WEAPON_HEAVY
 	w_class = WEIGHT_CLASS_BULKY
 	ammo_type = list(/obj/item/ammo_casing/energy/beam_rifle/hitscan)
-	cell_type = /obj/item/stock_parts/cell/beam_rifle
+	gun_charge = 500 KILOWATT //This is not a gun you use lightly
 	canMouseDown = TRUE
 	pin = null
 	var/aiming = FALSE


### PR DESCRIPTION
This fixes three guns, the beam rifle, the mining PKA and the temperature gun that hasn't been reported as broken yet. 

![dreamseeker_nQrTGaoor7](https://github.com/user-attachments/assets/7380d239-46e7-444f-ab86-2fa256c81ffd)

![dreamseeker_vz5M4EfItv](https://github.com/user-attachments/assets/cd0856e4-9857-4c18-b45b-03c9939a78f0)
